### PR TITLE
release: 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The return message of the registry is not standarized, please open a PR or creat
 <!-- start usage -->
 
 ```yaml
-- uses: tyriis/docker-image-tag-exists@v2026.6.1
+- uses: tyriis/docker-image-tag-exists@v3.0.0
   with:
     # The container image registry
     registry: docker.io

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-image-tag-exists",
-  "version": "2026.6.1",
+  "version": "3.0.0",
   "description": "This action query a docker container registry to check if a given tag exists",
   "type": "module",
   "main": "src/index.mjs",


### PR DESCRIPTION
Switch back to semver (v3.0.0) after two calver releases. Runtime: node20 → node24. [Regular merge](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github).