### PR TITLE
ci: exclude dist/ from pre-commit hooks that modify vendored code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: check-symlinks
       - id: check-vcs-permalinks
+        exclude: ^dist/
       - id: destroyed-symlinks
       - id: detect-aws-credentials
         args:
@@ -44,6 +45,7 @@ repos:
       - id: mixed-line-ending
       - id: no-commit-to-branch
       - id: trailing-whitespace
+        exclude: ^dist/
       # format-specific
       - id: check-json
       - id: check-toml
@@ -66,12 +68,15 @@ repos:
     hooks:
       - id: remove-crlf
       - id: remove-tabs
+        exclude: ^dist/
 
   - repo: https://github.com/sirosen/texthooks
     rev: 0.7.1
     hooks:
       - id: fix-smartquotes
+        exclude: ^dist/
       - id: fix-ligatures
+        exclude: ^dist/
       - id: forbid-bidi-controls
 
   - repo: https://github.com/igorshubovych/markdownlint-cli


### PR DESCRIPTION
The `dist/` directory is auto-generated by `ncc build` and contains vendored third-party code that pre-commit hooks shouldn't modify.

Excluded hooks:
- `check-vcs-permalinks` — bundled code has non-permanent GitHub links
- `trailing-whitespace` — bundled code may have trailing whitespace
- `remove-tabs` — bundled code uses tabs
- `fix-smartquotes` — bundled code may have smart quotes
- `fix-ligatures` — bundled code may have ligatures